### PR TITLE
Do not remove libnoise on `make clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ clean :
 	find . -name '*~' -exec rm {} ';'
 	$(MAKE) -C rwimg clean
 	$(MAKE) -C lispreader clean
-	rm -rf debian/mathmap debian/mathmap.substvars libnoise
+	rm -rf debian/mathmap debian/mathmap.substvars
 
 realclean : clean
 	rm -f new_builtins.c opdefs.h opfuncs.h llvm-ops.h new_template.c llvm_template.c backends/lazy_creator.cpp compiler_types.h parser.[ch] .nfs* mathmap-*.tar.gz


### PR DESCRIPTION
For whatever reason, libnoise is shipped as part of the MathMap distribution. It should not be removed by `make clean`.